### PR TITLE
fix linker error

### DIFF
--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -2,7 +2,7 @@
 
 printf 'Building... '
 for bin in encrypt decrypt; do
-    gcc -Wall -nostdlib -o $bin $bin.s
+    gcc -Wall -nostdlib -no-pie -o $bin $bin.s
 done
 printf 'done.\n'
 


### PR DESCRIPTION
relocation R_X86_64_32S against undefined symbol `buf' can not be used when making a PIE object
fixes #1 